### PR TITLE
changed sourceCompatibility to '1.8' (i.e. no Java 9 features used)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
-sourceCompatibility = 11.0
-targetCompatibility = 11.0
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 group 'io.tlf.jme'
 version '0.0.0'


### PR DESCRIPTION
In order to build this project in the JME 3.2 IDE, I had to change the source compatibility level. 