### PR TITLE
gitignore: ignore native libs extracted for Linux and macOS platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .gradle
 **/build
 *.dll
+*.dylib
+*.so
 /.gradle/
 /build/
 /.idea/


### PR DESCRIPTION
Just as DLL files should be ignored on Windows platforms, so should the DYLIB and SO files used on macOS and Linux platforms respectively.